### PR TITLE
Several small fixes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@ flask
 flask-sock>=0.5,<1.0
 flask-cors>=3.0.10,<3.1
 wxPython>=4.1.1
-plyer>=2.0.0,<2.1
+notify-py>=0.3.3,<0.4
+tendo>=0.2.15,<0.3


### PR DESCRIPTION
* Switch to notify-py to avoid a separate tray icon for each notification on Windows. Fixes Inter-Actief/JulianaNFC_Python#3
* Allow only one instance to be running. Fixes Inter-Actief/JulianaNFC_Python#4
* Fix crash when websocket is incorrectly closed client-side and a card is sent to the closed socket. Fixes Inter-Actief/JulianaNFC_Python#5